### PR TITLE
English l10n fixes proposal for the branch 7.4.3

### DIFF
--- a/modules/admin-gui/resources/languages/languagefile.en.properties
+++ b/modules/admin-gui/resources/languages/languagefile.en.properties
@@ -1777,7 +1777,7 @@ BACKTOPUBLISHERS          = Back to Publishers
 
 CA                        = CA
 
-CA_MGMT_HELP			  = ManagementCA is the administrative CA for this node, used for authenticating admins, create TLS keystores etc. 
+CA_MGMT_HELP			  = ManagementCA is the administrative CA for this node, used for authenticating admins, create TLS keystores, etc. 
 
 CAACTIVATED               = Certificate Response received successfully, CA Activated
 
@@ -2264,7 +2264,7 @@ MONITORED                 = Monitored
 
 MUSTSELECTATLEASTONEFIELD = You must select at least one DN field to match LDAP DN.
 
-NOALGORITHMWITHSELECTABLEKEYSIZE = No algorithm/curve with selectable key sized selected.
+NOALGORITHMWITHSELECTABLEKEYSIZE = No algorithm/curve with selectable key sizes selected.
 
 NOCACERTFILE              = No CA chain file available
 
@@ -2430,11 +2430,11 @@ SSH_CONFIGURATION         = SSH Configuration
 
 SSH_OPTION_FORCE_COMMAND  = Critical Option: force-command
 
-SSH_OPTION_FORCE_COMMAND_HELP = Specifies a command that is executed (replacing any the user specified on the ssh command-line) whenever this key is used for authentication. Will only be present in user certificates.
+SSH_OPTION_FORCE_COMMAND_HELP = Specifies a command that is executed (replacing any the user specified on the ssh command-line) whenever this key is used for authentication. Will only be present in client certificates.
 
 SSH_OPTION_SOURCE_ADDRESS = Critical Option: source-address
 
-SSH_OPTION_SOURCE_ADDRESS_HELP = Comma-separated list of source addresses from which this certificate is accepted for authentication. Addresses are specified in CIDR format (nn.nn.nn.nn/nn or hhhh::hhhh/nn).  If this option is not present then certificates may be presented from any source address. Will only be present in user certificates.
+SSH_OPTION_SOURCE_ADDRESS_HELP = Comma-separated list of source addresses from which this certificate is accepted for authentication. Addresses are specified in CIDR format (nn.nn.nn.nn/nn or hhhh::hhhh/nn).  If this option is not present then certificates may be presented from any source address. Will only be present in client certificates.
 
 SSH_PRINCIPAL             = Principal
 
@@ -3785,6 +3785,7 @@ RACMDLINE                 = RA user
 
 UNKNOWNCAID               = Unknown CA Identifier
 
+
 ### Mostly RA Module
 
 ADDDATASOURCE             = Add Data Source
@@ -4574,7 +4575,7 @@ PEERINTERNALKEYBINDINGUPDATERWORKER_ANYLOCALCA = Any active local X509 CA
 #-- Custom Service OcspResponseUpdater
 OCSPRESPONSEUPDATERWORKER_TITLE = OCSP Response Presigner
 OCSPRESPONSEUPDATERWORKER_GENERATEFORALLCERTS = Generate Responses for All Certificates
-OCSPRESPONSEUPDATERWORKER_GENERATEFORALLCERTS_HELP = Responses will be generated for all certificates issue by the selected CAs every time the worker runs.
+OCSPRESPONSEUPDATERWORKER_GENERATEFORALLCERTS_HELP = Responses will be generated for all certificates issued by the selected CAs every time the worker runs.
 OCSPRESPONSEUPDATERWORKER_UPDATEEXPIREDONLY = Update Expired Responses Only
 OCSPRESPONSEUPDATERWORKER_UPDATEEXPIREDONLY_HELP = Only checks already generated responses.
 OCSPRESPONSEUPDATERWORKER_WORKER_CAIDSTOCHECK = CAs to Check
@@ -4583,8 +4584,9 @@ OCSPRESPONSEUPDATERWORKER_WORKER_TIMEUNIT = Time Unit
 OCSPRESPONSEUPDATERWORKER_ISSUEFINALRESPONSE = Issue Final OCSP Response (eIDAS)
 OCSPRESPONSEUPDATERWORKER_TIMEBEFORECAEXPIRES = Time Before CA Expires
 OCSPRESPONSEUPDATERWORKER_TIMEUNITBEFORECAEXPIRES = Time Unit
-OCSPRESPONSEUPDATERWORKER_CERTIDHASHALGORITHM = CertId Hash Algorithm
+OCSPRESPONSEUPDATERWORKER_CERTIDHASHALGORITHM = CertID Hash Algorithm
 OCSPRESPONSEUPDATERWORKER_CERTIDHASHALGORITHM_HELP = Pre-signed responses will use the chosen hash algorithm
+
 
 ### Peer Connector module
 
@@ -4646,7 +4648,7 @@ PEERS_EDIT_DELETE_CONFIRM = Delete
 PEERS_EDIT_DELETE_HAS_PUBLISHERS = Cannot delete a peer connector that has active publishers ({0})
 PEERS_EDIT_ERR_UNAUTH = You are not authorized to this operation.
 PEERS_EDIT_ERR_NONAME = Name cannot be empty.
-PEERS_EDIT_ERR_NAME_ALREADY_EXIST = Name already exist.
+PEERS_EDIT_ERR_NAME_ALREADY_EXIST = Name already exists.
 PEERS_EDIT_ERR_INVALIDURL = Invalid URL.
 PEERS_EDIT_ERR_INVALIDURLHTTPS = Only the https protocol is allowed.
 PEERS_EDIT_ERR_NOAUTHANDENABLED = Peer connector cannot be enabled without outgoing credentials.
@@ -5028,8 +5030,8 @@ VALIDATORTYPE                                       = Validator Type
 VALIDATORALLCERTIFICATEPROFILES                     = Apply for all Certificate Profiles
 VALIDATORCERTIFICATEPROFILE                         = Apply for Certificate Profiles
 VALIDATOR_PERFORM_DURING                            = Perform Validation on
-VALIDATORNOTBEFORE                                  = Certificates Issued Not Before
-VALIDATORNOTAFTER                                   = Certificates Issued Not After
+VALIDATORNOTBEFORE                                  = Certificate Validity Not Before
+VALIDATORNOTAFTER                                   = Certificate Validity Not After
 
 #-- External Command Certificate Validator
 EXTERNALCOMMANDCERTIFICATEVALIDATOR                     = External Command Certificate Validator
@@ -5051,8 +5053,8 @@ EXTERNALCERTIFICATEVALIDATORCOMMANDNOTFOUND             = Command '{0}' could no
 #BLACKLISTKEYVALIDATOR                                  = Blacklist Key Validator
 PUBLICKEYBLACKLISTKEYVALIDATORSETTINGS                  = Blacklist Key Validator Settings
 PUBLICKEYBLACKLISTKEYVALIDATORKEYALGORITHMS             = Key Algorithms
-PUBLICKEYBLACKLISTKEYVALIDATORNOTBEFORECONDITION		= Certificates Issued Not Before
-PUBLICKEYBLACKLISTKEYVALIDATORNOTAFTERCONDITION			= Certificates Issued Not After
+PUBLICKEYBLACKLISTKEYVALIDATORNOTBEFORECONDITION		= Certificate Validity Not Before
+PUBLICKEYBLACKLISTKEYVALIDATORNOTAFTERCONDITION			= Certificate Validity Not After
 PUBLICKEYBLACKLISTKEYVALIDATORNOTBEFORE 				= ISO 8601 date: [yyyy-MM-dd HH:mm:ssZZ]: '2020-09-25 16:42:49+02:00'
 PUBLICKEYBLACKLISTKEYVALIDATORNOTAFTER					= ISO 8601 date: [yyyy-MM-dd HH:mm:ssZZ]: '2020-09-25 16:42:49+02:00'
 
@@ -5070,8 +5072,8 @@ RSAKEYVALIDATORPUBLICKEYMODULUSDONTALLOWROCAWEAKKEYS    = Don't allow ROCA weak 
 RSAKEYVALIDATORPUBLICKEYMODULUSMINFACTOR                = Public key modulus smallest factor
 RSAKEYVALIDATORPUBLICKEYMODULUSMIN                      = Public key modulus minimum value
 RSAKEYVALIDATORPUBLICKEYMODULUSMAX                      = Public key modulus maximum value
-RSAKEYVALIDATORNOTBEFORECONDITION						= Certificates Issued Not Before
-RSAKEYVALIDATORNOTAFTERCONDITION						= Certificates Issued Not After
+RSAKEYVALIDATORNOTBEFORECONDITION						= Certificate Validity Not Before
+RSAKEYVALIDATORNOTAFTERCONDITION						= Certificate Validity Not After
 RSAKEYVALIDATORNOTBEFORE 								= ISO 8601 date: [yyyy-MM-dd HH:mm:ssZZ]: '2020-09-25 16:42:49+02:00'
 RSAKEYVALIDATORNOTAFTER									= ISO 8601 date: [yyyy-MM-dd HH:mm:ssZZ]: '2020-09-25 16:42:49+02:00'
 
@@ -5126,8 +5128,8 @@ ECCKEYVALIDATORECCURVES                                 = Available curves
 ECCKEYVALIDATORAVAILABLECURVES                          = Available curves
 ECCKEYVALIDATORUSEFULLPUBLICKEYVALIDATION               = Use full public key validation
 ECCKEYVALIDATORUSEFULLPUBLICKEYVALIDATIONROUTINE        = Use full public key validation
-ECCKEYVALIDATORNOTBEFORECONDITION						= Certificates Issued Not Before
-ECCKEYVALIDATORNOTAFTERCONDITION						= Certificates Issued Not After
+ECCKEYVALIDATORNOTBEFORECONDITION						= Certificate Validity Not Before
+ECCKEYVALIDATORNOTAFTERCONDITION						= Certificate Validity Not After
 ECCKEYVALIDATORNOTBEFORE 								= ISO 8601 date: [yyyy-MM-dd HH:mm:ssZZ]: '2020-09-25 16:42:49+02:00'
 ECCKEYVALIDATORNOTAFTER									= ISO 8601 date: [yyyy-MM-dd HH:mm:ssZZ]: '2020-09-25 16:42:49+02:00'
 
@@ -5214,5 +5216,6 @@ CERTIFICATECRLREADER_SIGNING_CA_ID				    = Signing CA (if any)
 
 #-- Google Safe Browsing Validator
 GOOGLESAFEBROWSINGVALIDATORAPI_KEY                = API key
+
 
 ### EOF

--- a/modules/admin-gui/resources/languages/languagefile.en.properties
+++ b/modules/admin-gui/resources/languages/languagefile.en.properties
@@ -930,50 +930,6 @@ DN_SPAIN_CIF                = CIF, Tax ID code, for companies (Spain)
 
 DN_SPAIN_NIF                = NIF, Tax ID number, for individuals (Spain)
 
-#-- OAuth Key Management
-
-OAUTHKEYCONFIGURATION_EDIT_OAUTHKEY_TITLE	= Add or remove Trusted OAuth Providers
-
-OAUTHKEYCONFIGURATION_VIEW_OAUTHKEY_TITLE	= View current Trusted OAuth Providers
-
-OAUTHKEYCONFIGURATION_KEYIDENTIFIER	= OAuth Key Identifier
-
-OAUTHKEYCONFIGURATION_SKEWLIMIT	= Skew Limit (ms)
-
-OAUTHKEYCONFIGURATION_PUBLICKEY	= Public Key
-
-OAUTHKEYCONFIGURATION_ADD_NEW	= Add a New Trusted OAuth Provider
-
-OAUTHKEYCONFIGURATION_SET_DEFAULT	= Set a default Trusted OAuth Provider
-
-OAUTHKEYCONFIGURATION_DEFAULT	= Default Trusted OAuth Provider:
-
-OAUTHKEYCONFIGURATION_SAVE		= Save
-
-OAUTHKEYCONFIGURATION_PUBLICKEYFILE	= Base64, PEM or DER/CRT file:
-
-OAUTHKEYCONFIGURATION_EDITKEY	= Edit Trusted OAuth Provider
-
-OAUTHKEYCONFIGURATION_CURRENT_PUBLICKEY	= Current Public Key
-
-OAUTHKEYCONFIGURATION_REPLACE_PUBLICKEY	= New Public Key
-
-OAUTHKEYTAB_UPLOADFAILED  	= Upload of OAuth public key file failed.
-
-OAUTHKEYTAB_SKEWLIMITNEGATIVE  = Skew limit value may not be negative.
-
-OAUTHKEYTAB_BADKEYFILE    	= Cannot parse the public key file {0}. {1}
-
-OAUTHKEYTAB_GENERICADDERROR  = Cannot add Trusted OAuth Provider. {0}
-
-OAUTHKEYTAB_ALREADYEXISTS 	= An Trusted OAuth Provider with that key id already exists
-
-OAUTHKEYTAB_EDITKEYIDNOTPOSSIBLE	= Cannot edit OAuth key identifier for public key used to verify current administrator token.
-
-OAUTHKEYTAB_EDITDEFAULTKEYNOTPOSSIBLE	= Cannot edit default trusted OAuth Provider used to verify current administrator token.
-
-OAUTHKEYTAB_PUBLICKEYREMOVALNOTPOSSIBLE	= Cannot remove public key used to verify current administrator token. 	
-
 #-- Extended Key Usage
 
 EKU_EDIT_EKU_TITLE          = Add or remove available Extended Key Usages
@@ -3099,6 +3055,50 @@ EJBCA_COMMON_ISSUESET_TITLE = EJBCA Common
 EJBCA_COMMON_ISSUESET_DESCRIPTION = Track configuration issues commonly found on EJBCA installations. It is recommended to always have this configuration issue set enabled.
 CT_ISSUESET_TITLE = Certificate Transparency
 CT_ISSUESET_DESCRIPTION = Track configuration issues related to Certificate Transparency. Should be enabled if this instance is publishing to CT logs.
+
+#-- OAuth Key Management
+
+OAUTHKEYCONFIGURATION_EDIT_OAUTHKEY_TITLE	= Add or remove Trusted OAuth Providers
+
+OAUTHKEYCONFIGURATION_VIEW_OAUTHKEY_TITLE	= View current Trusted OAuth Providers
+
+OAUTHKEYCONFIGURATION_KEYIDENTIFIER	= OAuth Key Identifier
+
+OAUTHKEYCONFIGURATION_SKEWLIMIT	= Skew Limit (ms)
+
+OAUTHKEYCONFIGURATION_PUBLICKEY	= Public Key
+
+OAUTHKEYCONFIGURATION_ADD_NEW	= Add a New Trusted OAuth Provider
+
+OAUTHKEYCONFIGURATION_SET_DEFAULT	= Set a default Trusted OAuth Provider
+
+OAUTHKEYCONFIGURATION_DEFAULT	= Default Trusted OAuth Provider:
+
+OAUTHKEYCONFIGURATION_SAVE		= Save
+
+OAUTHKEYCONFIGURATION_PUBLICKEYFILE	= Base64, PEM or DER/CRT file:
+
+OAUTHKEYCONFIGURATION_EDITKEY	= Edit Trusted OAuth Provider
+
+OAUTHKEYCONFIGURATION_CURRENT_PUBLICKEY	= Current Public Key
+
+OAUTHKEYCONFIGURATION_REPLACE_PUBLICKEY	= New Public Key
+
+OAUTHKEYTAB_UPLOADFAILED  	= Upload of OAuth public key file failed.
+
+OAUTHKEYTAB_SKEWLIMITNEGATIVE  = Skew limit value may not be negative.
+
+OAUTHKEYTAB_BADKEYFILE    	= Cannot parse the public key file {0}. {1}
+
+OAUTHKEYTAB_GENERICADDERROR  = Cannot add Trusted OAuth Provider. {0}
+
+OAUTHKEYTAB_ALREADYEXISTS 	= An Trusted OAuth Provider with that key id already exists
+
+OAUTHKEYTAB_EDITKEYIDNOTPOSSIBLE	= Cannot edit OAuth key identifier for public key used to verify current administrator token.
+
+OAUTHKEYTAB_EDITDEFAULTKEYNOTPOSSIBLE	= Cannot edit default trusted OAuth Provider used to verify current administrator token.
+
+OAUTHKEYTAB_PUBLICKEYREMOVALNOTPOSSIBLE	= Cannot remove public key used to verify current administrator token. 	
 
 #-- My Preferences
 


### PR DESCRIPTION
Fixes are:
* Typo/error (e.g. punctuation, etc.)
* File code syntax (e.g. double CR before big section starting with `###`)
* Ambiguous term 'Issued' in message 'Certificates Issued Not [Before/After]'
* Moving of 'OAuth Key Management' subsection (in this right big section)

**Note:** all the messages `Certificates Issued Not [Before/After]` had been replaced by the better messages from the online documentation, _i.e._ `Certificate Validity Not [Before/After]`.
Reference: https://doc.primekey.com/ejbca/ejbca-operations/ejbca-ca-concept-guide/validators-overview/key-validators#KeyValidators-CommonKeyValidatorSettingsCommon_Key_Validator_Settings